### PR TITLE
Fix `[` command failure when $rules is empty

### DIFF
--- a/execop.zsh
+++ b/execop.zsh
@@ -4,7 +4,7 @@ add-zsh-hook preexec -execop-preexec
 -execop-preexec() {
     local rules=`-execop-gather-dotfiles`
     local cmd="${1}"
-    if [ $rules = '' ]; then
+    if [ "${rules}" = '' ]; then
         return
     fi
     local IFS=$'\n'


### PR DESCRIPTION
Fix this error when no .execop file is found.

```
-execop-preexec:3: parse error: condition expected: =
```

We may need fix other occurrences of `[ $variable = $value ]`, but this is at least a solution to an existing problem.